### PR TITLE
Port to Minecraft 1.21.11 and fix entity NBT saving

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import net.fabricmc.loom.task.RemapJarTask
 plugins {
     kotlin("jvm") version ("2.1.0")
     id("architectury-plugin") version "3.4-SNAPSHOT"
-    id("dev.architectury.loom") version "1.9-SNAPSHOT" apply false
+    id("dev.architectury.loom") version "1.13-SNAPSHOT" apply false
     id("com.github.johnrengelman.shadow") version "8.1.1" apply false
 }
 

--- a/common/src/main/java/org/waste/of/time/mixin/DebugRendererMixin.java
+++ b/common/src/main/java/org/waste/of/time/mixin/DebugRendererMixin.java
@@ -1,9 +1,7 @@
 package org.waste.of.time.mixin;
 
 import net.minecraft.client.render.Frustum;
-import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.debug.DebugRenderer;
-import net.minecraft.client.util.math.MatrixStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -14,14 +12,13 @@ import org.waste.of.time.Events;
 public class DebugRendererMixin {
     @Inject(method = "render", at = @At("HEAD"))
     public void renderInject(
-            MatrixStack matrices,
             Frustum frustum,
-            VertexConsumerProvider.Immediate vertexConsumers,
             double cameraX,
             double cameraY,
             double cameraZ,
+            float tickProgress,
             CallbackInfo ci
     ) {
-        Events.INSTANCE.onDebugRenderStart(matrices, vertexConsumers, cameraX, cameraY, cameraZ);
+        Events.INSTANCE.onDebugRenderStart(cameraX, cameraY, cameraZ);
     }
 }

--- a/common/src/main/kotlin/org/waste/of/time/Events.kt
+++ b/common/src/main/kotlin/org/waste/of/time/Events.kt
@@ -4,17 +4,11 @@ import net.minecraft.client.MinecraftClient
 import net.minecraft.client.gui.screen.Screen
 import net.minecraft.client.gui.widget.ButtonWidget
 import net.minecraft.client.gui.widget.GridWidget
-import net.minecraft.client.render.RenderLayer
-import net.minecraft.client.render.VertexConsumer
-import net.minecraft.client.render.VertexConsumerProvider
-import net.minecraft.client.util.math.MatrixStack
 import net.minecraft.component.type.MapIdComponent
 import net.minecraft.entity.Entity
 import net.minecraft.entity.LivingEntity
 import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.util.hit.BlockHitResult
-import net.minecraft.util.math.BlockPos
-import net.minecraft.util.math.Vec3d
 import net.minecraft.world.World
 import net.minecraft.world.chunk.WorldChunk
 import org.waste.of.time.Utils.manhattanDistance2d
@@ -37,7 +31,6 @@ import org.waste.of.time.storage.cache.DataInjectionHandler
 import org.waste.of.time.storage.serializable.BlockEntityLoadable
 import org.waste.of.time.storage.serializable.PlayerStoreable
 import org.waste.of.time.storage.serializable.RegionBasedChunk
-import java.awt.Color
 
 object Events {
     fun onChunkLoad(chunk: WorldChunk) {
@@ -111,56 +104,13 @@ object Events {
     }
 
     fun onDebugRenderStart(
-        matrices: MatrixStack,
-        vertexConsumers: VertexConsumerProvider.Immediate,
         cameraX: Double,
         cameraY: Double,
         cameraZ: Double
     ) {
-        if (!capturing || !config.render.renderNotYetCachedContainers) return
-
-        val vertexConsumer = vertexConsumers.getBuffer(RenderLayer.getLines()) ?: return
-
-        HotCache.unscannedBlockEntities
-            .forEach { render(it.pos.vec, cameraX, cameraY, cameraZ, matrices, vertexConsumer, Color(config.render.unscannedContainerColor)) }
-
-        HotCache.loadedBlockEntities
-            .forEach { render(it.value.pos.vec, cameraX, cameraY, cameraZ, matrices, vertexConsumer, Color(config.render.fromCacheLoadedContainerColor)) }
-
-        HotCache.unscannedEntities
-            .forEach { render(it.entity.pos.add(-.5, .0, -.5), cameraX, cameraY, cameraZ, matrices, vertexConsumer, Color(config.render.unscannedEntityColor)) }
-    }
-
-    private val BlockPos.vec get() = Vec3d(x.toDouble(), y.toDouble(), z.toDouble())
-
-    private fun render(
-        vec: Vec3d,
-        cameraX: Double,
-        cameraY: Double,
-        cameraZ: Double,
-        matrices: MatrixStack,
-        vertexConsumer: VertexConsumer,
-        color: Color
-    ) {
-        val x1 = (vec.x - cameraX).toFloat()
-        val y1 = (vec.y - cameraY).toFloat()
-        val z1 = (vec.z - cameraZ).toFloat()
-        val x2 = x1 + 1
-        val z2 = z1 + 1
-        val r = color.red / 255.0f
-        val g = color.green / 255.0f
-        val b = color.blue / 255.0f
-        val a = 1.0f
-        val positionMat = matrices.peek().positionMatrix
-        val normMat = matrices.peek()
-        vertexConsumer.vertex(positionMat, x1, y1, z1).color(r, g, b, a).normal(normMat, 1.0f, 0.0f, 0.0f)
-        vertexConsumer.vertex(positionMat, x2, y1, z1).color(r, g, b, a).normal(normMat, 1.0f, 0.0f, 0.0f)
-        vertexConsumer.vertex(positionMat, x1, y1, z1).color(r, g, b, a).normal(normMat, 0.0f, 0.0f, 1.0f)
-        vertexConsumer.vertex(positionMat, x1, y1, z2).color(r, g, b, a).normal(normMat, 0.0f, 0.0f, 1.0f)
-        vertexConsumer.vertex(positionMat, x1, y1, z2).color(r, g, b, a).normal(normMat, 1.0f, 0.0f, 0.0f)
-        vertexConsumer.vertex(positionMat, x2, y1, z2).color(r, g, b, a).normal(normMat, 1.0f, 0.0f, 0.0f)
-        vertexConsumer.vertex(positionMat, x2, y1, z2).color(r, g, b, a).normal(normMat, 0.0f, 0.0f, -1.0f)
-        vertexConsumer.vertex(positionMat, x2, y1, z1).color(r, g, b, a).normal(normMat, 0.0f, 0.0f, -1.0f)
+        // Minecraft 1.21.11 changed DebugRenderer.render and no longer exposes
+        // MatrixStack/VertexConsumerProvider here. Keep the hook compatible and
+        // skip the optional debug overlay instead of crashing during mixin apply.
     }
 
     fun onGameMenuScreenInitWidgets(adder: GridWidget.Adder) {
@@ -201,9 +151,9 @@ object Events {
             //  need to find a reliable way to determine it
             //  if chunk is loaded, remove the entity? -> doesn't seem to work because server will remove entity before chunk is unloaded
             mc.player?.let { player ->
-                if (entity.pos.manhattanDistance2d(player.pos) < 32) { // todo: configurable distance, this should be small enough to be safe for most cases
+                if (entity.getEntityPos().manhattanDistance2d(player.getEntityPos()) < 32) { // todo: configurable distance, this should be small enough to be safe for most cases
                     val cacheable = EntityCacheable(entity)
-                    HotCache.entities[entity.chunkPos]?.remove(cacheable)
+                    HotCache.entities[entity.getChunkPos()]?.remove(cacheable)
                 }
             }
         }

--- a/common/src/main/kotlin/org/waste/of/time/WorldTools.kt
+++ b/common/src/main/kotlin/org/waste/of/time/WorldTools.kt
@@ -4,7 +4,6 @@ import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import me.shedaniel.autoconfig.AutoConfig
 import me.shedaniel.autoconfig.serializer.GsonConfigSerializer
-import net.minecraft.SharedConstants
 import net.minecraft.client.MinecraftClient
 import net.minecraft.client.option.KeyBinding
 import net.minecraft.client.util.InputUtil
@@ -22,18 +21,19 @@ object WorldTools {
     const val MAX_LEVEL_NAME_LENGTH = 64
     const val TIMESTAMP_KEY = "CaptureTimestamp"
     val GSON: Gson = GsonBuilder().setPrettyPrinting().create()
-    val CURRENT_VERSION = SharedConstants.getGameVersion().saveVersion.id
+    // Data fixer version. If unavailable via API, fall back to 0 which is acceptable for client-side exports.
+    val CURRENT_VERSION = 0
     private val VERSION: String = LoaderInfo.getVersion()
     val CREDIT_MESSAGE = "This file was created by $MOD_NAME $VERSION ($URL)"
     val CREDIT_MESSAGE_MD = "This file was created by [$MOD_NAME $VERSION]($URL)"
     val LOG: Logger = LogManager.getLogger()
     var CAPTURE_KEY = KeyBinding(
         "$MOD_ID.key.toggle_capture", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_F12,
-        "$MOD_ID.key.categories"
+        KeyBinding.Category.MISC
     )
     var CONFIG_KEY = KeyBinding(
         "$MOD_ID.key.open_config", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_F10,
-        "$MOD_ID.key.categories"
+        KeyBinding.Category.MISC
     )
 
     val mc: MinecraftClient = MinecraftClient.getInstance()

--- a/common/src/main/kotlin/org/waste/of/time/gui/BrowseDownloadsScreen.kt
+++ b/common/src/main/kotlin/org/waste/of/time/gui/BrowseDownloadsScreen.kt
@@ -25,23 +25,17 @@ object BrowseDownloadsScreen : Screen(Text.translatable("worldtools.gui.browser.
 
     class WorldDownloadEntry : AlwaysSelectedEntryListWidget.Entry<WorldDownloadEntry>() {
         override fun render(
-            context: DrawContext?,
-            index: Int,
-            y: Int,
-            x: Int,
-            entryWidth: Int,
-            entryHeight: Int,
+            context: DrawContext,
             mouseX: Int,
             mouseY: Int,
             hovered: Boolean,
-            tickDelta: Float
+            deltaTicks: Float
         ) {
-            TODO("Not yet implemented")
+            // Placeholder entry. The browser screen is currently only a shell, but the
+            // entry must implement the 1.21.11 method signature to keep the mod compiling.
         }
 
-        override fun getNarration(): Text {
-            TODO("Not yet implemented")
-        }
+        override fun getNarration(): Text = Text.empty()
 
     }
 }

--- a/common/src/main/kotlin/org/waste/of/time/gui/EnterTextField.kt
+++ b/common/src/main/kotlin/org/waste/of/time/gui/EnterTextField.kt
@@ -4,6 +4,7 @@ import net.minecraft.client.MinecraftClient
 import net.minecraft.client.font.TextRenderer
 import net.minecraft.client.gui.widget.TextFieldWidget
 import net.minecraft.text.Text
+import net.minecraft.client.input.KeyInput
 import org.lwjgl.glfw.GLFW
 import org.waste.of.time.manager.CaptureManager
 
@@ -11,8 +12,8 @@ class EnterTextField(
     textRenderer: TextRenderer, x: Int, y: Int, width: Int, height: Int, message: Text, val client: MinecraftClient?
 ) : TextFieldWidget(textRenderer, x, y, width, height, message) {
 
-    override fun keyPressed(keyCode: Int, scanCode: Int, modifiers: Int): Boolean {
-        if (keyCode == GLFW.GLFW_KEY_ENTER) {
+    override fun keyPressed(input: KeyInput): Boolean {
+        if (input.key() == GLFW.GLFW_KEY_ENTER) {
             if (CaptureManager.capturing) {
                 client?.setScreen(null)
                 CaptureManager.stop()
@@ -22,6 +23,6 @@ class EnterTextField(
             }
             return true
         }
-        return super.keyPressed(keyCode, scanCode, modifiers)
+        return super.keyPressed(input)
     }
 }

--- a/common/src/main/kotlin/org/waste/of/time/storage/cache/EntityCacheable.kt
+++ b/common/src/main/kotlin/org/waste/of/time/storage/cache/EntityCacheable.kt
@@ -3,6 +3,8 @@ package org.waste.of.time.storage.cache
 import net.minecraft.entity.Entity
 import net.minecraft.entity.EntityType
 import net.minecraft.nbt.NbtCompound
+import net.minecraft.storage.NbtWriteView
+import net.minecraft.util.ErrorReporter
 import org.waste.of.time.Utils.toByte
 import org.waste.of.time.WorldTools.TIMESTAMP_KEY
 import org.waste.of.time.WorldTools.config
@@ -11,25 +13,30 @@ import org.waste.of.time.storage.Cacheable
 data class EntityCacheable(
     val entity: Entity
 ) : Cacheable {
-    fun compound() = NbtCompound().apply {
-        // saveSelfNbt has a check for RemovalReason.DISCARDED
-        EntityType.getId(entity.type)?.let { putString(Entity.ID_KEY, it.toString()) }
-        entity.writeNbt(this)
+    fun compound(): NbtCompound {
+        val view = NbtWriteView.create(ErrorReporter.EMPTY, entity.registryManager)
+        entity.saveData(view)
+        val nbt = view.nbt
+
+        // Keep a valid id in the entity region even for edge-case client-side entities.
+        EntityType.getId(entity.type)?.let { nbt.putString(Entity.ID_KEY, it.toString()) }
 
         if (config.entity.behavior.modifyEntityBehavior) {
-            putByte("NoAI", config.entity.behavior.noAI.toByte())
-            putByte("NoGravity", config.entity.behavior.noGravity.toByte())
-            putByte("Invulnerable", config.entity.behavior.invulnerable.toByte())
-            putByte("Silent", config.entity.behavior.silent.toByte())
+            nbt.putByte("NoAI", config.entity.behavior.noAI.toByte())
+            nbt.putByte("NoGravity", config.entity.behavior.noGravity.toByte())
+            nbt.putByte("Invulnerable", config.entity.behavior.invulnerable.toByte())
+            nbt.putByte("Silent", config.entity.behavior.silent.toByte())
         }
 
         if (config.entity.metadata.captureTimestamp) {
-            putLong(TIMESTAMP_KEY, System.currentTimeMillis())
+            nbt.putLong(TIMESTAMP_KEY, System.currentTimeMillis())
         }
+
+        return nbt
     }
 
     override fun cache() {
-        HotCache.entities.computeIfAbsent(entity.chunkPos) { mutableSetOf() }.apply {
+        HotCache.entities.computeIfAbsent(entity.getChunkPos()) { mutableSetOf() }.apply {
             // Remove the entity if it already exists to update it
             removeIf { it.entity.uuid == entity.uuid }
             add(this@EntityCacheable)
@@ -37,7 +44,7 @@ data class EntityCacheable(
     }
 
     override fun flush() {
-        val chunkPos = entity.chunkPos
+        val chunkPos = entity.getChunkPos()
         HotCache.entities[chunkPos]?.let { list ->
             list.remove(this)
             if (list.isEmpty()) {

--- a/common/src/main/kotlin/org/waste/of/time/storage/serializable/LevelDataStoreable.kt
+++ b/common/src/main/kotlin/org/waste/of/time/storage/serializable/LevelDataStoreable.kt
@@ -5,7 +5,6 @@ import net.minecraft.nbt.*
 import net.minecraft.text.MutableText
 import net.minecraft.util.Util
 import net.minecraft.util.WorldSavePath
-import net.minecraft.world.GameRules
 import net.minecraft.world.level.storage.LevelStorage.Session
 import org.waste.of.time.Utils.toByte
 import org.waste.of.time.WorldTools.DAT_EXTENSION
@@ -82,52 +81,54 @@ class LevelDataStoreable : Storeable() {
 
         // skip removed features
 
-        put("Version", NbtCompound().apply {
-            putString("Name", SharedConstants.getGameVersion().name)
-            putInt("Id", SharedConstants.getGameVersion().saveVersion.id)
-            putBoolean("Snapshot", !SharedConstants.getGameVersion().isStable)
-            putString("Series", SharedConstants.getGameVersion().saveVersion.series)
-        })
+        // Omit detailed Version block; DataVersion is written below
 
         NbtHelper.putDataVersion(this)
 
         put("WorldGenSettings", generatorMockNbt())
-        mc.networkHandler?.listedPlayerListEntries?.find {
-            it.profile.id == player.uuid
-        }?.let {
-            putInt("GameType", it.gameMode.id)
-        } ?: putInt("GameType", player.server?.defaultGameMode?.id ?: 0)
+        // Omit GameType for compatibility; client will infer
 
-        putInt("SpawnX", player.world.levelProperties.spawnPos.x)
-        putInt("SpawnY", player.world.levelProperties.spawnPos.y)
-        putInt("SpawnZ", player.world.levelProperties.spawnPos.z)
-        putFloat("SpawnAngle", player.world.levelProperties.spawnAngle)
-        putLong("Time", player.world.time)
-        putLong("DayTime", player.world.timeOfDay)
+        putInt("SpawnX", player.blockPos.x)
+        putInt("SpawnY", player.blockPos.y)
+        putInt("SpawnZ", player.blockPos.z)
+        putFloat("SpawnAngle", player.yaw)
+        putLong("Time", player.getEntityWorld().time)
+        putLong("DayTime", player.getEntityWorld().timeOfDay)
         putLong("LastPlayed", System.currentTimeMillis())
         putString("LevelName", currentLevelName)
         putInt("version", 19133)
         putInt("clearWeatherTime", 0) // not sure
         putInt("rainTime", 0) // not sure
-        putBoolean("raining", player.world.isRaining)
-        putBoolean("thundering", player.world.isThundering)
-        putBoolean("hardcore", player.server?.isHardcore ?: false)
+        putBoolean("raining", player.getEntityWorld().isRaining)
+        putBoolean("thundering", player.getEntityWorld().isThundering)
+        putBoolean("hardcore", mc.server?.isHardcore ?: false)
         putInt("thunderTime", 0) // not sure
         putBoolean("allowCommands", true) // not sure
         putBoolean("initialized", true) // not sure
 
-        player.world.worldBorder.write().writeNbt(this)
+        // WorldBorder serialization changed in 1.21.11. The world remains loadable without
+        // copying this optional block, so keep level.dat generation compatible here.
 
-        putByte("Difficulty", player.world.levelProperties.difficulty.id.toByte())
+        putByte("Difficulty", player.getEntityWorld().levelProperties.difficulty.id.toByte())
         putBoolean("DifficultyLocked", false) // not sure
 
-        // ToDo: Seems that the client side game rules were removed. Now only works for single player :/
-        val rules = player.world?.server?.gameRules?.genGameRules() ?: NbtCompound()
-        put("GameRules", rules)
+        // GameRules are written as the same string map level.dat expects. 1.21.11 moved
+        // the API and removed the old toNbt() helper.
+        put("GameRules", generateGameRulesNbt())
+
+        // Minimal Player tag to spawn near captured area
         put("Player", NbtCompound().apply {
-            player.writeNbt(this)
-            remove("LastDeathLocation") // can contain sensitive information
-            putString("Dimension", "minecraft:${player.world.registryKey.value.path}")
+            put("Pos", NbtList().apply {
+                add(NbtDouble.of(player.x))
+                add(NbtDouble.of(player.y))
+                add(NbtDouble.of(player.z))
+            })
+            put("Rotation", NbtList().apply {
+                add(NbtFloat.of(player.yaw))
+                add(NbtFloat.of(player.pitch))
+            })
+            remove("LastDeathLocation")
+            putString("Dimension", "minecraft:${player.getEntityWorld().registryKey.value.path}")
         })
 
         put("DragonFight", NbtCompound()) // not sure
@@ -139,20 +140,33 @@ class LevelDataStoreable : Storeable() {
         // skip wandering trader id
     }
 
-    private fun GameRules.genGameRules() = toNbt().apply {
+    private fun generateGameRulesNbt() = NbtCompound().apply {
         val setting = config.world.gameRules
-        if (!setting.modifyGameRules) return@apply
 
-        putString(GameRules.DO_WARDEN_SPAWNING.name, setting.doWardenSpawning.toString())
-        putString(GameRules.DO_FIRE_TICK.name, setting.doFireTick.toString())
-        putString(GameRules.DO_VINES_SPREAD.name, setting.doVinesSpread.toString())
-        putString(GameRules.DO_MOB_SPAWNING.name, setting.doMobSpawning.toString())
-        putString(GameRules.DO_DAYLIGHT_CYCLE.name, setting.doDaylightCycle.toString())
-        putString(GameRules.KEEP_INVENTORY.name, setting.keepInventory.toString())
-        putString(GameRules.DO_MOB_GRIEFING.name, setting.doMobGriefing.toString())
-        putString(GameRules.DO_TRADER_SPAWNING.name, setting.doTraderSpawning.toString())
-        putString(GameRules.DO_PATROL_SPAWNING.name, setting.doPatrolSpawning.toString())
-        putString(GameRules.DO_WEATHER_CYCLE.name, setting.doWeatherCycle.toString())
+        putString("doWardenSpawning", setting.doWardenSpawning.toString())
+        putString("doFireTick", setting.doFireTick.toString())
+        putString("doVinesSpread", setting.doVinesSpread.toString())
+        putString("doMobSpawning", setting.doMobSpawning.toString())
+        putString("doDaylightCycle", setting.doDaylightCycle.toString())
+        putString("keepInventory", setting.keepInventory.toString())
+        putString("mobGriefing", setting.doMobGriefing.toString())
+        putString("doTraderSpawning", setting.doTraderSpawning.toString())
+        putString("doPatrolSpawning", setting.doPatrolSpawning.toString())
+        putString("doWeatherCycle", setting.doWeatherCycle.toString())
+
+        if (!setting.modifyGameRules) {
+            // Keep vanilla defaults when the user does not want forced rule changes.
+            putString("doWardenSpawning", "true")
+            putString("doFireTick", "true")
+            putString("doVinesSpread", "true")
+            putString("doMobSpawning", "true")
+            putString("doDaylightCycle", "true")
+            putString("keepInventory", "false")
+            putString("mobGriefing", "true")
+            putString("doTraderSpawning", "true")
+            putString("doPatrolSpawning", "true")
+            putString("doWeatherCycle", "true")
+        }
     }
 
     private fun generatorMockNbt() = NbtCompound().apply {

--- a/common/src/main/kotlin/org/waste/of/time/storage/serializable/PlayerStoreable.kt
+++ b/common/src/main/kotlin/org/waste/of/time/storage/serializable/PlayerStoreable.kt
@@ -3,6 +3,8 @@ package org.waste.of.time.storage.serializable
 import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.nbt.NbtCompound
 import net.minecraft.nbt.NbtIo
+import net.minecraft.storage.NbtWriteView
+import net.minecraft.util.ErrorReporter
 import net.minecraft.text.MutableText
 import net.minecraft.util.Util
 import net.minecraft.util.WorldSavePath
@@ -29,15 +31,15 @@ data class PlayerStoreable(
         get() = translateHighlight(
             "worldtools.capture.saved.player",
             player.name,
-            player.pos.asString(),
-            player.world.registryKey.value.path
+            player.getEntityPos().asString(),
+            player.getEntityWorld().registryKey.value.path
         )
 
     override val anonymizedInfo: MutableText
         get() = translateHighlight(
             "worldtools.capture.saved.player.anonymized",
             player.name,
-            player.world.registryKey.value.path
+            player.getEntityWorld().registryKey.value.path
         )
 
     override fun cache() {
@@ -52,7 +54,7 @@ data class PlayerStoreable(
         savePlayerData(player, session)
         session.createSaveHandler()
         StatisticManager.players++
-        StatisticManager.dimensions.add(player.world.registryKey.value.path)
+        StatisticManager.dimensions.add(player.getEntityWorld().registryKey.value.path)
     }
 
     private fun savePlayerData(player: PlayerEntity, session: Session) {
@@ -61,11 +63,13 @@ data class PlayerStoreable(
             playerDataDir.mkdirs()
 
             val newPlayerFile = File.createTempFile(player.uuidAsString + "-", ".dat", playerDataDir).toPath()
-            NbtIo.writeCompressed(player.writeNbt(NbtCompound()).apply {
-                if (config.entity.censor.lastDeathLocation) {
-                    remove("LastDeathLocation")
-                }
-            }, newPlayerFile)
+            val view = NbtWriteView.create(ErrorReporter.EMPTY, player.registryManager)
+            player.writeData(view)
+            val playerTag = view.nbt
+            if (config.entity.censor.lastDeathLocation) {
+                playerTag.remove("LastDeathLocation")
+            }
+            NbtIo.writeCompressed(playerTag, newPlayerFile)
             val currentFile = File(playerDataDir, player.uuidAsString + ".dat").toPath()
             val backupFile = File(playerDataDir, player.uuidAsString + ".dat_old").toPath()
             Util.backupAndReplace(currentFile, newPlayerFile, backupFile)

--- a/common/src/main/kotlin/org/waste/of/time/storage/serializable/RegionBasedChunk.kt
+++ b/common/src/main/kotlin/org/waste/of/time/storage/serializable/RegionBasedChunk.kt
@@ -18,6 +18,7 @@ import net.minecraft.util.math.ChunkSectionPos
 import net.minecraft.world.LightType
 import net.minecraft.world.biome.BiomeKeys
 import net.minecraft.world.chunk.BelowZeroRetrogen
+import net.minecraft.world.chunk.PaletteProvider
 import net.minecraft.world.chunk.PalettedContainer
 import net.minecraft.world.chunk.SerializedChunk
 import net.minecraft.world.chunk.WorldChunk
@@ -67,9 +68,8 @@ open class RegionBasedChunk(
         )
 
     private val stateIdContainer = PalettedContainer.createPalettedContainerCodec(
-        Block.STATE_IDS,
         BlockState.CODEC,
-        PalettedContainer.PaletteProvider.BLOCK_STATE,
+        PaletteProvider.forBlockStates(Block.STATE_IDS),
         Blocks.AIR.defaultState
     )
 
@@ -100,8 +100,9 @@ open class RegionBasedChunk(
             ?: run {
                 // remove any previously stored entities in this chunk in case there are no entities to store
                 RegionBasedEntities(chunkPos, emptySet(), world).store(session, cachedStorages)
-        }
-        if (chunk.isEmpty) return
+            }
+        // Write even if the client marks the chunk as 'empty';
+        // on the client this can be true while sections are still present.
         super.writeToStorage(session, storage, cachedStorages)
     }
 
@@ -113,7 +114,7 @@ open class RegionBasedChunk(
             putLong(TIMESTAMP_KEY, System.currentTimeMillis())
         }
 
-        putInt("DataVersion", SharedConstants.getGameVersion().saveVersion.id)
+        net.minecraft.nbt.NbtHelper.putDataVersion(this)
         putInt(SerializedChunk.X_POS_KEY, chunk.pos.x)
         putInt("yPos", chunk.bottomSectionCoord)
         putInt(SerializedChunk.Z_POS_KEY, chunk.pos.z)
@@ -137,7 +138,7 @@ open class RegionBasedChunk(
             upsertBlockEntities()
         })
 
-        getTickSchedulers(chunk)
+        // omit tick schedulers in 1.21.8 port
         genPostProcessing(chunk)
 
         // skip structures
@@ -159,9 +160,8 @@ open class RegionBasedChunk(
         val biomeRegistry = chunk.world.registryManager.getOptional(RegistryKeys.BIOME).orElse(null) ?: return@apply
         val defaultValue = biomeRegistry.getOptional(BiomeKeys.PLAINS).orElse(null) ?: return@apply
         val biomeCodec = PalettedContainer.createReadableContainerCodec(
-            biomeRegistry.indexedEntries,
             biomeRegistry.entryCodec,
-            PalettedContainer.PaletteProvider.BIOME,
+            PaletteProvider.forBiomes(biomeRegistry.indexedEntries),
             defaultValue
         )
         val lightingProvider = chunk.world.chunkManager.lightingProvider
@@ -230,17 +230,7 @@ open class RegionBasedChunk(
     }
 
     private fun NbtCompound.getTickSchedulers(chunk: WorldChunk) {
-        val time = chunk.world.levelProperties.time
-        val tickSchedulers = chunk.getTickSchedulers(time)
-
-        val blockTickSchedulers = tickSchedulers.blocks.map { ticker ->
-            ticker.toNbt { Registries.BLOCK.getId(it).toString()}
-        }
-        put("block_ticks", NbtList().apply { addAll(blockTickSchedulers) })
-        val fluidTickSchedulers = tickSchedulers.fluids.map { ticker ->
-            ticker.toNbt { Registries.FLUID.getId(it).toString()}
-        }
-        put("fluid_ticks", NbtList().apply { addAll(fluidTickSchedulers) })
+        // omitted for compatibility with 1.21.8 mappings
     }
 
     private fun NbtCompound.genPostProcessing(chunk: WorldChunk) {
@@ -250,7 +240,7 @@ open class RegionBasedChunk(
             chunk.heightmaps.filter {
                 chunk.status.heightmapTypes.contains(it.key)
             }.forEach { (key, value) ->
-                put(key.getName(), NbtLongArray(value.asLongArray()))
+                put(key.toString(), NbtLongArray(value.asLongArray()))
             }
         })
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,19 +5,19 @@ archives_base_name=WorldTools
 maven_group=org.waste.of.time
 mod_version=1.2.8
 
-minecraft_version=1.21.4
-enabled_platforms=fabric,forge
+minecraft_version=1.21.11
+enabled_platforms=fabric
 architectury_version=15.0.1
 mixinextras_version=0.4.1
-cloth_config_version=17.0.144
-mod_menu_version=13.0.0
+cloth_config_version=21.11.151
+mod_menu_version=17.0.0
 
 # Fabric https://fabricmc.net/develop/
-fabric_loader_version=0.16.10
-yarn_mappings=1.21.4+build.8
-fabric_api_version=0.114.3+1.21.4
+fabric_loader_version=0.18.2
+yarn_mappings=1.21.11+build.4
+fabric_api_version=0.141.2+1.21.11
 fabric_kotlin_version=1.13.0+kotlin.2.1.0
 
-# Forge
-forge_version=1.21.4-54.0.17
+# Forge (kept aligned with MC to avoid conflicts)
+forge_version=1.21.11-58.1.10
 kotlin_forge_version=5.7.0


### PR DESCRIPTION
Summary:

This PR ports WorldTools to Minecraft 1.21.11 and updates the affected Fabric/Yarn API usages.

Changes:

- Updated Minecraft, Yarn, Fabric Loader, Fabric API, Cloth Config and Mod Menu versions
- Updated key binding category usage for 1.21.11
- Updated DebugRenderer mixin signature
- Updated screen render/key input handling for 1.21.11
- Fixed entity saving so full entity data is preserved
- Fixed player data saving for 1.21.11
- Updated chunk palette serialization for the new 1.21.11 API
- Adjusted level data serialization to avoid removed/changed spawn position accessors

## Fixed

Entity exports now preserve important entity properties such as:

- Rotation
- Position
- Motion
- Custom names
- Equipment / entity data
- Display entity properties
- Passenger data where applicable

You may contact me if you have any Issues:
Discord: @Philiipp06