### PR TITLE
fix: clear progress bossbar after drain completes

### DIFF
--- a/common/src/main/kotlin/org/waste/of/time/storage/StorageFlow.kt
+++ b/common/src/main/kotlin/org/waste/of/time/storage/StorageFlow.kt
@@ -75,11 +75,13 @@ object StorageFlow {
             LOG.info("Canceled caching thread")
         } catch (e: Throwable) {
             LOG.error("Unhandled storage flow error", e)
+            MessageManager.sendError("worldtools.log.error.unhandled_drain_failure", levelName, e.localizedMessage)
         }
 
         cachedStorages.values.forEach { it.close() }
         HotCache.clear()
         CaptureManager.capturing = false
+        lastStored = null
         LOG.info("Finished caching")
     }
 

--- a/common/src/main/resources/assets/worldtools/lang/en_us.json
+++ b/common/src/main/resources/assets/worldtools/lang/en_us.json
@@ -137,6 +137,7 @@
   "worldtools.log.error.failed_to_visit_file": "Failed accessing file %s to create a zip! (error: %s)",
   "worldtools.log.error.failed_to_zip": "Failed to create session to zip capture of %s! (error: %s)",
   "worldtools.log.error.not_capturing": "No capture is running yet!",
+  "worldtools.log.error.unhandled_drain_failure": "Capture drain failed for %s: %s. The world directory may be incomplete.",
   "worldtools.log.error.world_name_too_long": "World name \"%s\" is too long! (max %d characters)",
   "worldtools.log.info.singleplayer_capture": "EXPERIMENTAL: Capturing in singleplayer is experimental and may not work as expected!",
   "worldtools.log.info.started_capture": "Started capturing %s...",


### PR DESCRIPTION
BarManager.progressBar() returns the bossbar widget whenever StorageFlow.lastStored is non-null. The decay-and-clear path lives in BarManager.updateCapture(), which only runs while capturing is true. After the drain finishes (capturing flips to false), the bossbar persists at whatever fill it last had until the next capture starts.

The symptom is most visible when the drain spans a server change: disconnect mid-drain, reconnect to another server, then the stale bossbar from the previous server's capture lingers on the new server's HUD when the drain completes.

Clear lastStored in StorageFlow's cleanup block so progressBar() returns empty as soon as the drain ends.

With the bossbar gone, the existing catch (e: Throwable) at the bottom of StorageFlow.launch became the sole place an unexpected drain failure could surface, and it only logged. Add a MessageManager.sendError on the same path so a user without log access still sees the failure, mirroring the existing sendError on the IOException and SymlinkValidationException catches above it.

## Verification

Bossbar widget cleared at drain end, verified across a server-change scenario (disconnect mid-drain, reconnect to a different server, drain finishes; HUD now empty instead of carrying a stale fill).
