### PR TITLE
fix: keep game-menu button in sync with capture state

### DIFF
--- a/common/src/main/kotlin/org/waste/of/time/Events.kt
+++ b/common/src/main/kotlin/org/waste/of/time/Events.kt
@@ -1,6 +1,7 @@
 package org.waste.of.time
 
 import net.minecraft.client.MinecraftClient
+import net.minecraft.client.gui.screen.GameMenuScreen
 import net.minecraft.client.gui.screen.Screen
 import net.minecraft.client.gui.widget.ButtonWidget
 import net.minecraft.client.gui.widget.GridWidget
@@ -12,6 +13,7 @@ import net.minecraft.component.type.MapIdComponent
 import net.minecraft.entity.Entity
 import net.minecraft.entity.LivingEntity
 import net.minecraft.entity.player.PlayerEntity
+import net.minecraft.text.Text
 import net.minecraft.util.hit.BlockHitResult
 import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.Vec3d
@@ -40,6 +42,17 @@ import org.waste.of.time.storage.serializable.RegionBasedChunk
 import java.awt.Color
 
 object Events {
+    // Built once per GameMenuScreen init and refreshed from the tick because
+    // `capturing` can flip while the menu stays open. Cleared on screen removal
+    // so the per-tick refresh can short-circuit when no menu is showing.
+    private var menuButton: ButtonWidget? = null
+
+    private fun menuButtonLabel(): Text = when {
+        capturing && CaptureManager.stopping -> translateHighlight("worldtools.gui.escape.button.saving", currentLevelName)
+        capturing -> translateHighlight("worldtools.gui.escape.button.finish_download", currentLevelName)
+        else -> MessageManager.brand
+    }
+
     fun onChunkLoad(chunk: WorldChunk) {
         if (!capturing) return
         RegionBasedChunk(chunk).cache()
@@ -80,6 +93,10 @@ object Events {
         if (CONFIG_KEY.wasPressed() && mc.world != null && mc.currentScreen == null) {
             mc.setScreen(ManagerScreen)
         }
+
+        // Must run before the !capturing guard: the most important refresh is
+        // the true->false flip at drain end, which the guard would skip.
+        refreshMenuButton()
 
         if (!capturing) return
         updateCapture()
@@ -164,22 +181,30 @@ object Events {
     }
 
     fun onGameMenuScreenInitWidgets(adder: GridWidget.Adder) {
-        val widget = if (capturing) {
-            val label = translateHighlight("worldtools.gui.escape.button.finish_download", currentLevelName)
-            ButtonWidget.builder(label) {
+        // Route at click time, not build time: 'capturing' can flip while the
+        // menu stays open, so the wrong handler would fire on a stale label.
+        val widget = ButtonWidget.builder(menuButtonLabel()) {
+            if (capturing) {
                 CaptureManager.stop()
                 mc.setScreen(null)
-            }.width(204).build()
-        } else {
-            ButtonWidget.builder(MessageManager.brand) {
+            } else {
                 MinecraftClient.getInstance().setScreen(ManagerScreen)
-            }.width(204).build()
-        }
+            }
+        }.width(204).build()
+        widget.active = !(capturing && CaptureManager.stopping)
 
+        menuButton = widget
         adder.add(widget, 2)
     }
 
+    private fun refreshMenuButton() {
+        val btn = menuButton ?: return
+        btn.message = menuButtonLabel()
+        btn.active = !(capturing && CaptureManager.stopping)
+    }
+
     fun onScreenRemoved(screen: Screen) {
+        if (screen is GameMenuScreen) menuButton = null
         if (!capturing) return
         DataInjectionHandler.onScreenRemoved(screen)
         HotCache.lastInteractedBlockEntity = null

--- a/common/src/main/resources/assets/worldtools/lang/en_us.json
+++ b/common/src/main/resources/assets/worldtools/lang/en_us.json
@@ -122,6 +122,7 @@
   "worldtools.gui.capture.existing_world_confirm.message": "A save named: \"%s\" already exists. Overwrite it? (Will merge with existing data)",
   "worldtools.gui.capture.existing_world_confirm.title": "Existing World Found",
   "worldtools.gui.escape.button.finish_download": "Save capture of %s",
+  "worldtools.gui.escape.button.saving": "Saving capture of %s...",
   "worldtools.gui.manager.button.cancel": "Cancel",
   "worldtools.gui.manager.button.config": "Config",
   "worldtools.gui.manager.button.start_download": "Start download",


### PR DESCRIPTION
The escape-menu button was built once on screen init and captured both its label and click action at build time. When capturing flipped while the menu stayed open the button went stale in two visible ways: after the drain finished the "Save Capture" label remained and clicks routed to stop() on a not-capturing state; during the drain itself the button still said "Save Capture" and was clickable even though the click was a no-op via the stopping sentinel.

Route the click handler by current state at click time and drive both the label and the active flag from (capturing, stopping) via a per-tick refresh: idle shows "WorldTools"; capturing-not-stopping shows "Save Capture" clickable; stopping shows "Saving capture of <name>..." disabled. The refresh runs before the !capturing guard so the true->false flip at drain end fires.

## Verification

Menu-button label and click behaviour stay in sync across drain start and end (verified by opening the escape menu before, during, and after a capture).