### PR TITLE
fix: omit isLightOn so MC recomputes lighting on world load

### DIFF
--- a/common/src/main/kotlin/org/waste/of/time/storage/serializable/RegionBasedChunk.kt
+++ b/common/src/main/kotlin/org/waste/of/time/storage/serializable/RegionBasedChunk.kt
@@ -129,9 +129,11 @@ open class RegionBasedChunk(
 
         put(SerializedChunk.SECTIONS_KEY, generateSections(chunk))
 
-        if (chunk.isLightOn) {
-            putBoolean(SerializedChunk.IS_LIGHT_ON_KEY, true)
-        }
+        // Don't set isLightOn for client-captured chunks.
+        // LightData packets mark sections as uninitialized via per-chunk bitsets,
+        // so a capture typically holds light data for only some sections. Setting
+        // isLightOn=true would make MC trust the flag and skip relighting those
+        // gaps; omit it so MC recomputes lighting on world load.
 
         put("block_entities", NbtList().apply {
             upsertBlockEntities()


### PR DESCRIPTION
Captured chunks were emitting isLightOn = true based on the client's view, but LightData packets mark sections as uninitialized via per-chunk bitsets, so a capture typically holds light data for only some sections. On load MC trusts the flag and skips recomputation, leaving dark patches in the captured world.

Drop the flag entirely. MC's lightmap pass on world load produces correct results from the saved sections.