### PR TITLE
fix: make CaptureManager.stop() idempotent during drain

### DIFF
--- a/common/src/main/kotlin/org/waste/of/time/manager/CaptureManager.kt
+++ b/common/src/main/kotlin/org/waste/of/time/manager/CaptureManager.kt
@@ -23,6 +23,11 @@ import org.waste.of.time.storage.serializable.*
 object CaptureManager {
     private const val MAX_WORLD_NAME_LENGTH = 64
     var capturing = false
+
+    // True between the first stop() call and the drain's cleanup running.
+    // Re-entries during this window (stale-button clicks, onClientDisconnect)
+    // would otherwise re-emit the whole HotCache and spam chat.
+    var stopping = false
     private var storeJob: Job? = null
     var currentLevelName: String = "Not yet initialized"
     var lastPlayer: ClientPlayerEntity? = null
@@ -106,6 +111,11 @@ object CaptureManager {
             MessageManager.sendError("worldtools.log.error.not_capturing")
             return
         }
+        if (stopping) {
+            LOG.info("stop() ignored: drain already in progress for $currentLevelName")
+            return
+        }
+        stopping = true
 
         MessageManager.sendInfo("worldtools.log.info.stopping_capture", currentLevelName)
 

--- a/common/src/main/kotlin/org/waste/of/time/storage/StorageFlow.kt
+++ b/common/src/main/kotlin/org/waste/of/time/storage/StorageFlow.kt
@@ -80,6 +80,7 @@ object StorageFlow {
         cachedStorages.values.forEach { it.close() }
         HotCache.clear()
         CaptureManager.capturing = false
+        CaptureManager.stopping = false
         LOG.info("Finished caching")
     }
 


### PR DESCRIPTION
stop() guarded only on !capturing, but the StorageFlow drain runs for up to a minute on big captures with capturing still true. Re-entries in that window (stale button clicks, onClientDisconnect on reconnect) re-emitted the whole HotCache and spammed "Stopping capture..." chat. Add a stopping sentinel reset by the drain's cleanup block.

## Verification

No double-stop and no "Stopping capture..." chat spam on disconnect-during-drain (verified by triggering disconnect while a multi-second drain was in flight).