### PR TITLE
fix: skip onClientJoin cleanup while a prior drain is still running

### DIFF
--- a/common/src/main/kotlin/org/waste/of/time/Events.kt
+++ b/common/src/main/kotlin/org/waste/of/time/Events.kt
@@ -86,6 +86,18 @@ object Events {
     }
 
     fun onClientJoin() {
+        // A prior capture's StorageFlow drain may still be running; touching
+        // HotCache/lastStored/stats here would zero EndFlow's counters and
+        // delete entity data in unprocessed chunks. The drain's own cleanup
+        // clears HotCache when it finishes, so the next capture starts clean.
+        if (capturing) {
+            // Surface the skip when autoDownload is enabled: the user opted in
+            // to "capture on join" and would otherwise see no feedback.
+            if (config.general.autoDownload) {
+                MessageManager.sendInfo("worldtools.log.info.autodownload_skipped_drain_in_progress")
+            }
+            return
+        }
         HotCache.clear()
         StorageFlow.lastStored = null
         StatisticManager.reset()

--- a/common/src/main/resources/assets/worldtools/lang/en_us.json
+++ b/common/src/main/resources/assets/worldtools/lang/en_us.json
@@ -138,6 +138,7 @@
   "worldtools.log.error.failed_to_zip": "Failed to create session to zip capture of %s! (error: %s)",
   "worldtools.log.error.not_capturing": "No capture is running yet!",
   "worldtools.log.error.world_name_too_long": "World name \"%s\" is too long! (max %d characters)",
+  "worldtools.log.info.autodownload_skipped_drain_in_progress": "Auto-download skipped: a previous capture is still saving. Wait for it to finish before re-joining.",
   "worldtools.log.info.singleplayer_capture": "EXPERIMENTAL: Capturing in singleplayer is experimental and may not work as expected!",
   "worldtools.log.info.started_capture": "Started capturing %s...",
   "worldtools.log.info.stopping_capture": "Stopping capture %s..."


### PR DESCRIPTION
Reconnecting during the post-stop StorageFlow drain re-entered Events.onClientJoin which unconditionally ran StatisticManager.reset() and HotCache.clear(). The reset zeroed chunks/entities/players/containers mid-drain so EndFlow read all-zero counters and reported nothing_saved_yet, and the clear wiped HotCache.entities for chunks the IO coroutine had not yet processed, causing RegionBasedChunk.writeToStorage's null-branch to overwrite entity data for those chunks with an empty entities NBT.

Guard onClientJoin with if (capturing) return so an in-flight drain keeps its state. When autoDownload is enabled, emit a MessageManager sendInfo before the guard so users who opted into capture-on-join see why no capture started on the new server. autoDownload on the new server is forgone in this window; acceptable trade-off, the prior capture is finishing.

## Verification

Drain survives reconnect to a different server without state wipe: EndFlow counters stay accurate and the captured region keeps its entity data instead of being overwritten with empty entity NBT.