### PR TITLE
fix: tolerate per-entity NBT codec failures in region save

### DIFF
--- a/common/src/main/kotlin/org/waste/of/time/storage/serializable/RegionBasedEntities.kt
+++ b/common/src/main/kotlin/org/waste/of/time/storage/serializable/RegionBasedEntities.kt
@@ -42,7 +42,13 @@ class RegionBasedEntities(
     override fun compound() = NbtCompound().apply {
         put("Entities", NbtList().apply {
             entities.forEach { entity ->
-                add(entity.compound())
+                try {
+                    add(entity.compound())
+                } catch (e: Exception) {
+                    // Skip the bad entity; otherwise the catch in
+                    // RegionBased.writeToStorage drops every entity in the chunk.
+                    LOG.error("Failed to serialize entity ${entity.entity} in chunk $chunkPos; skipping it", e)
+                }
             }
         })
 


### PR DESCRIPTION
Region-level catch in RegionBased.writeToStorage was whole-chunk-fatal: one entity whose writeData throws dropped every entity in the region. Observed in the wild via a vanilla LeashData NPE on a newer MC version, but the same shape can be triggered by any per-entity codec failure on 1.21.4.

Wrap the per-entity add() in RegionBasedEntities.compound with its own catch so the bad entity is logged with full stack and skipped, while the rest of the region writes.

## Verification

Indirect: requires an entity with a codec failure to fire. No reproducer in routine 1.21.4 testing; the failure mode was observed on a newer MC version (vanilla LeashData NPE), which motivated the defensive change. With the per-entity catch in place no entity-codec failure can take down a region.

## Note

Overlaps the goal of closed PR #94 ("fix entity NBT saving"); the implementation here is narrower (per-entity try/catch around add(), not a global swallow).