### PR TITLE
fix: tolerate per-map IO failures in MapDataStoreable

### DIFF
--- a/common/src/main/kotlin/org/waste/of/time/storage/serializable/MapDataStoreable.kt
+++ b/common/src/main/kotlin/org/waste/of/time/storage/serializable/MapDataStoreable.kt
@@ -42,17 +42,24 @@ class MapDataStoreable : Storeable() {
                 HotCache.mapIDs.contains(component.id)
             }?.forEach { (component, mapState) ->
                 val id = component.id
-                NbtCompound().apply {
-                    put("data", mapState.writeNbt(NbtCompound(), world.registryManager))
-                    NbtHelper.putDataVersion(this)
-                    val mapFile = dataDirectory.resolve("map_$id${WorldTools.DAT_EXTENSION}")
-                    if (!mapFile.exists()) {
-                        mapFile.toFile().createNewFile()
+                try {
+                    NbtCompound().apply {
+                        put("data", mapState.writeNbt(NbtCompound(), world.registryManager))
+                        NbtHelper.putDataVersion(this)
+                        val mapFile = dataDirectory.resolve("map_$id${WorldTools.DAT_EXTENSION}")
+                        if (!mapFile.exists()) {
+                            mapFile.toFile().createNewFile()
+                        }
+                        NbtIo.writeCompressed(this, mapFile)
+                        if (config.debug.logSavedMaps) {
+                            LOG.info("Map data saved: $id")
+                        }
                     }
-                    NbtIo.writeCompressed(this, mapFile)
-                    if (config.debug.logSavedMaps) {
-                        LOG.info("Map data saved: $id")
-                    }
+                } catch (e: Exception) {
+                    // A single map's codec / IO / permissions failure must not
+                    // abort the rest of the drain. Mirrors the per-entity catch
+                    // in RegionBasedEntities.compound (d5bdf62).
+                    LOG.error("Failed to save map data for $id", e)
                 }
             }
         }


### PR DESCRIPTION
MapDataStoreable.store()'s per-map block calls mapState.writeNbt, file creation, and NbtIo.writeCompressed without try/catch. A single corrupted map's NBT codec, a transient IO error, or a permissions issue would throw out of the forEach into StorageFlow.launch's catch-all and silently abort the rest of the drain, losing every map after the failure.

Wrap the inner NbtCompound().apply { ... } block in try/catch and LOG.error the failing map id with the exception. Same shape as the per-entity catch in RegionBasedEntities.compound: tolerate one bad item so the rest of the iteration completes. Especially relevant for map-heavy captures where one bad NBT no longer dooms the rest of the maparts. The per-iteration lastStoredTimestamp refresh stays outside the try so the progressBar keeps refreshing across a problem map.

## Verification

Defensive hardening; no in-the-wild reproducer triggered in this capture. The symmetric per-entity catch in RegionBasedEntities.compound prevents analogous whole-region loss from vanilla codec failures observed on a newer MC version.