### PR TITLE
fix: keep progressBar alive during MapDataStoreable iterations

### DIFF
--- a/common/src/main/kotlin/org/waste/of/time/storage/serializable/MapDataStoreable.kt
+++ b/common/src/main/kotlin/org/waste/of/time/storage/serializable/MapDataStoreable.kt
@@ -13,6 +13,7 @@ import org.waste.of.time.WorldTools.mc
 import org.waste.of.time.manager.CaptureManager
 import org.waste.of.time.manager.MessageManager
 import org.waste.of.time.storage.CustomRegionBasedStorage
+import org.waste.of.time.storage.StorageFlow
 import org.waste.of.time.storage.Storeable
 import org.waste.of.time.storage.cache.HotCache
 import kotlin.io.path.exists
@@ -38,6 +39,12 @@ class MapDataStoreable : Storeable() {
         }
 
         mc.world?.let { world ->
+            // Seed lastStored so the progressBar renders this storeable's text
+            // during the loop below; refresh lastStoredTimestamp per iteration
+            // so BarManager's decay-clear does not hide the bar mid-save on
+            // map-heavy captures (10k+ maparts on anarchy servers).
+            StorageFlow.lastStored = this
+
             world.mapStates?.filter { (component, _) ->
                 HotCache.mapIDs.contains(component.id)
             }?.forEach { (component, mapState) ->
@@ -54,6 +61,7 @@ class MapDataStoreable : Storeable() {
                         LOG.info("Map data saved: $id")
                     }
                 }
+                StorageFlow.lastStoredTimestamp = System.currentTimeMillis()
             }
         }
     }


### PR DESCRIPTION
MapDataStoreable.store() writes each map_*.dat synchronously in its forEach loop. On captures with thousands of maparts the loop blocks the IO coroutine for many seconds without touching StorageFlow.lastStoredTimestamp, so BarManager.updateCapture's decay branch (default 3000ms) clears lastStored and the progressBar widget disappears mid-save.

Mirror the timestamp-refresh pattern from MetadataStoreable and CompressLevelStoreable: refresh lastStoredTimestamp per iteration, and seed lastStored at store() entry so the progressBar text reads "Saved maps in dimension X" through the slow phase.

## Verification

progressBar stays visible during MapDataStoreable on a 2b2t mapart-exhibition reproducer (10k+ maparts), confirmed across the full save phase instead of vanishing after ~3s of forEach blocking.