### PR TITLE
fix: harden HotCache entity sets against CME and chunk-wipe races

### DIFF
--- a/common/src/main/kotlin/org/waste/of/time/storage/cache/EntityCacheable.kt
+++ b/common/src/main/kotlin/org/waste/of/time/storage/cache/EntityCacheable.kt
@@ -7,6 +7,7 @@ import org.waste.of.time.Utils.toByte
 import org.waste.of.time.WorldTools.TIMESTAMP_KEY
 import org.waste.of.time.WorldTools.config
 import org.waste.of.time.storage.Cacheable
+import java.util.concurrent.ConcurrentHashMap
 
 data class EntityCacheable(
     val entity: Entity
@@ -29,7 +30,9 @@ data class EntityCacheable(
     }
 
     override fun cache() {
-        HotCache.entities.computeIfAbsent(entity.chunkPos) { mutableSetOf() }.apply {
+        // newKeySet: client-thread cache/flush mutations race the IO coroutine's
+        // forEach in RegionBasedEntities.compound; a plain HashSet CMEs there.
+        HotCache.entities.computeIfAbsent(entity.chunkPos) { ConcurrentHashMap.newKeySet() }.apply {
             // Remove the entity if it already exists to update it
             removeIf { it.entity.uuid == entity.uuid }
             add(this@EntityCacheable)

--- a/common/src/main/kotlin/org/waste/of/time/storage/cache/HotCache.kt
+++ b/common/src/main/kotlin/org/waste/of/time/storage/cache/HotCache.kt
@@ -57,7 +57,9 @@ object HotCache {
 
     fun getEntitySerializableForChunk(chunkPos: ChunkPos, world: World) =
         entities[chunkPos]?.let { entities ->
-            RegionBasedEntities(chunkPos, entities, world)
+            // snapshot guards the isEmpty()/forEach in RegionBasedEntities against
+            // the live newKeySet flipping empty between lookup and write
+            RegionBasedEntities(chunkPos, entities.toSet(), world)
         }
 
     /**


### PR DESCRIPTION
HotCache.entities's inner sets are mutated from the MC client thread (EntityCacheable.cache, Events.onEntityRemoved) and read on Dispatchers.IO by StorageFlow's drain through RegionBasedEntities. Two races surface:

- RegionBasedEntities.compound's forEach over a plain HashSet throws CME from HashIterator.next, tripping RegionBased.writeToStorage's outer catch, which drops the whole chunk's entities.
- writeToStorage's entities.isEmpty() check races onEntityRemoved between the HotCache lookup and the read, firing storage.write(chunkPos, null) on a chunk that should have been written. On re-capture this deletes the prior capture's entity file.

Switch the inner set to ConcurrentHashMap.newKeySet so iteration is weakly consistent, and snapshot the live set in HotCache.getEntitySerializableForChunk so isEmpty() and the forEach in compound() observe the same view.

## Verification

Indirect on the CME side: would surface as "Failed to store" entries in log; none observed across recent archive-survival captures with the fix applied. The chunk-wipe race is harder to trigger synthetically; the snapshot guarantees `isEmpty()` and the subsequent `forEach` agree on the same view.