### PR TITLE
feat: preserve PersistenceRequired and add forceMobPersistence

### DIFF
--- a/common/src/main/kotlin/org/waste/of/time/config/WorldToolsConfig.kt
+++ b/common/src/main/kotlin/org/waste/of/time/config/WorldToolsConfig.kt
@@ -136,6 +136,9 @@ class WorldToolsConfig : ConfigData {
             var noGravity = true
             var invulnerable = true
             var silent = true
+
+            @Tooltip
+            var forceMobPersistence = false
         }
 
         class Metadata {

--- a/common/src/main/kotlin/org/waste/of/time/storage/cache/EntityCacheable.kt
+++ b/common/src/main/kotlin/org/waste/of/time/storage/cache/EntityCacheable.kt
@@ -2,6 +2,7 @@ package org.waste.of.time.storage.cache
 
 import net.minecraft.entity.Entity
 import net.minecraft.entity.EntityType
+import net.minecraft.entity.mob.MobEntity
 import net.minecraft.nbt.NbtCompound
 import org.waste.of.time.Utils.toByte
 import org.waste.of.time.WorldTools.TIMESTAMP_KEY
@@ -21,6 +22,14 @@ data class EntityCacheable(
             putByte("NoGravity", config.entity.behavior.noGravity.toByte())
             putByte("Invulnerable", config.entity.behavior.invulnerable.toByte())
             putByte("Silent", config.entity.behavior.silent.toByte())
+        }
+
+        // PersistenceRequired is server-authoritative and arrives as false on the
+        // client, so name-tagged mobs would despawn after world load. Restore the
+        // flag here: always for named mobs (vanilla's NameTagItem path), and for
+        // every mob when the aggressive opt-in is set.
+        if (entity is MobEntity && (entity.hasCustomName() || config.entity.behavior.forceMobPersistence)) {
+            putByte("PersistenceRequired", 1)
         }
 
         if (config.entity.metadata.captureTimestamp) {

--- a/common/src/main/resources/assets/worldtools/lang/en_us.json
+++ b/common/src/main/resources/assets/worldtools/lang/en_us.json
@@ -29,6 +29,8 @@
   "text.autoconfig.worldtools.option.entity.behavior.noAI": "No AI",
   "text.autoconfig.worldtools.option.entity.behavior.noGravity": "No Gravity",
   "text.autoconfig.worldtools.option.entity.behavior.silent": "Silent",
+  "text.autoconfig.worldtools.option.entity.behavior.forceMobPersistence": "Force Mob Persistence",
+  "text.autoconfig.worldtools.option.entity.behavior.forceMobPersistence.@Tooltip": "Mark every captured mob as PersistenceRequired so none despawn after world load. Name-tagged mobs are already preserved automatically; enable this only if you want ambient mobs (skeletons, zombies, etc.) to stick around forever in the downloaded world.",
   "text.autoconfig.worldtools.option.entity.censor": "Censor",
   "text.autoconfig.worldtools.option.entity.censor.censorNames": "Censor Names",
   "text.autoconfig.worldtools.option.entity.censor.lastDeathLocation": "Censor last death location",


### PR DESCRIPTION
Vanilla persistence semantics state that a mob with a custom name should survive chunk unload (PersistenceRequired = true on the NBT). Captures were emitting these mobs without the flag, so loading a captured world and walking out of view caused the mob to despawn, which players reasonably treated as a capture bug.

Always set PersistenceRequired on name-tagged mobs at capture time, matching vanilla expectations. Expose forceMobPersistence (default off) for users who want the same guarantee extended to every captured mob, at the cost of vanilla despawn behaviour across the whole capture.

## Verification

26 / 26 name-tagged entities in server capture capture have `PersistenceRequired = 1` after the fix.

## Note

Adds a config flag and one lang key in en_us. 