### PR TITLE
feat: capture chiseled bookshelf inventory on right-click (#56)

### DIFF
--- a/common/src/main/java/org/waste/of/time/mixin/ClientPlayInteractionManagerMixin.java
+++ b/common/src/main/java/org/waste/of/time/mixin/ClientPlayInteractionManagerMixin.java
@@ -26,7 +26,7 @@ public class ClientPlayInteractionManagerMixin {
     @Inject(method = "interactBlock", at = @At("HEAD"))
     public void interactBlockHead(final ClientPlayerEntity player, final Hand hand, final BlockHitResult hitResult, final CallbackInfoReturnable<ActionResult> cir) {
         if (client.world == null) return;
-        Events.INSTANCE.onInteractBlock(client.world, hitResult);
+        Events.INSTANCE.onInteractBlock(client.world, hitResult, player, hand);
     }
 
     @Inject(method = "interactEntity", at = @At("HEAD"))

--- a/common/src/main/kotlin/org/waste/of/time/Events.kt
+++ b/common/src/main/kotlin/org/waste/of/time/Events.kt
@@ -12,6 +12,8 @@ import net.minecraft.component.type.MapIdComponent
 import net.minecraft.entity.Entity
 import net.minecraft.entity.LivingEntity
 import net.minecraft.entity.player.PlayerEntity
+import net.minecraft.text.Text
+import net.minecraft.util.Hand
 import net.minecraft.util.hit.BlockHitResult
 import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.Vec3d
@@ -97,11 +99,17 @@ object Events {
         CaptureManager.stop()
     }
 
-    fun onInteractBlock(world: World, hitResult: BlockHitResult) {
+    fun onInteractBlock(world: World, hitResult: BlockHitResult, player: PlayerEntity, hand: Hand) {
         if (!capturing) return
         val blockEntity = world.getBlockEntity(hitResult.blockPos)
         HotCache.lastInteractedBlockEntity = blockEntity
         HotCache.lastInteractedEntity = null
+
+        // Chiseled bookshelves never sync their inventory to the client and the player
+        // interacts with individual slots without opening a screen, so onScreenRemoved
+        // can't see this. Snapshot the hand item into the local block entity so the
+        // generic chunk capture path serializes the books the player just placed.
+        DataInjectionHandler.onChiseledBookshelfInteract(world, hitResult, blockEntity, player.getStackInHand(hand))
     }
 
     fun onInteractEntity(entity: Entity) {

--- a/common/src/main/kotlin/org/waste/of/time/storage/cache/DataInjectionHandler.kt
+++ b/common/src/main/kotlin/org/waste/of/time/storage/cache/DataInjectionHandler.kt
@@ -1,6 +1,7 @@
 package org.waste.of.time.storage.cache
 
 import net.minecraft.block.ChestBlock
+import net.minecraft.block.ChiseledBookshelfBlock
 import net.minecraft.block.entity.*
 import net.minecraft.block.enums.ChestType
 import net.minecraft.client.gui.screen.Screen
@@ -11,6 +12,10 @@ import net.minecraft.entity.vehicle.HopperMinecartEntity
 import net.minecraft.entity.vehicle.VehicleInventory
 import net.minecraft.inventory.EnderChestInventory
 import net.minecraft.inventory.SimpleInventory
+import net.minecraft.item.ItemStack
+import net.minecraft.registry.tag.ItemTags
+import net.minecraft.util.hit.BlockHitResult
+import net.minecraft.world.World
 import org.waste.of.time.WorldTools.mc
 import org.waste.of.time.storage.cache.HotCache.markScanned
 import org.waste.of.time.storage.cache.HotCache.scannedBlockEntities
@@ -207,4 +212,49 @@ object DataInjectionHandler {
     }
 
     private fun HandledScreen<*>.getContainerSlots() = screenHandler.slots.filter { it.inventory !is PlayerInventory }
+
+    /**
+     * Called from [org.waste.of.time.Events.onInteractBlock] HEAD-side, before the server
+     * has processed the interaction. Predicts the post-interaction inventory of a
+     * chiseled bookshelf and writes it to the local block entity so the chunk
+     * serializer picks it up.
+     *
+     * The server never sends a chiseled bookshelf's inventory to the client, so the
+     * only way to recover it is to observe the player placing books slot-by-slot.
+     * Books pulled from a previously-stocked shelf that the local capture never saw
+     * are unrecoverable.
+     *
+     * Optimistic-write caveat: we write the predicted slot state at HEAD time, before
+     * the server has confirmed the interaction. If the server rejects (reach distance,
+     * cooldown, permissions, custom plugin guard), the local cache diverges from the
+     * server's actual state until the next blockstate sync corrects it. Capture
+     * fidelity depends on the player not interacting through rejected actions.
+     */
+    fun onChiseledBookshelfInteract(
+        world: World,
+        hitResult: BlockHitResult,
+        blockEntity: BlockEntity?,
+        handStack: ItemStack,
+    ) {
+        if (blockEntity !is ChiseledBookshelfBlockEntity) return
+        val state = world.getBlockState(hitResult.blockPos)
+        val block = state.block as? ChiseledBookshelfBlock ?: return
+        val slotOpt = block.getSlotForHitPos(hitResult, state)
+        if (slotOpt.isEmpty) return
+        val slot = slotOpt.asInt
+        val occupied = state.get(ChiseledBookshelfBlock.SLOT_OCCUPIED_PROPERTIES[slot])
+        if (occupied) {
+            // Removal: vanilla onUse will return the existing book to the player. We
+            // don't know what the server actually had there; clear whatever we
+            // optimistically cached so the saved NBT matches the synced blockstate.
+            blockEntity.setStack(slot, ItemStack.EMPTY)
+        } else if (handStack.isIn(ItemTags.BOOKSHELF_BOOKS)) {
+            // Addition: vanilla onUseWithItem decrements the hand stack by one and
+            // stores a single-item copy in the slot.
+            blockEntity.setStack(slot, handStack.copyWithCount(1))
+        } else {
+            return
+        }
+        blockEntity.markScanned()
+    }
 }

--- a/common/src/main/kotlin/org/waste/of/time/storage/cache/HotCache.kt
+++ b/common/src/main/kotlin/org/waste/of/time/storage/cache/HotCache.kt
@@ -2,6 +2,7 @@ package org.waste.of.time.storage.cache
 
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet
 import net.minecraft.block.entity.BlockEntity
+import net.minecraft.block.entity.ChiseledBookshelfBlockEntity
 import net.minecraft.block.entity.LecternBlockEntity
 import net.minecraft.block.entity.LockableContainerBlockEntity
 import net.minecraft.entity.Entity
@@ -53,6 +54,7 @@ object HotCache {
     val BlockEntity.isSupported get() =
         this is LockableContainerBlockEntity
                 || this is LecternBlockEntity
+                || this is ChiseledBookshelfBlockEntity
     val Entity.isSupported get() = this is VehicleInventory
 
     fun getEntitySerializableForChunk(chunkPos: ChunkPos, world: World) =

--- a/common/src/main/kotlin/org/waste/of/time/storage/serializable/BlockEntityLoadable.kt
+++ b/common/src/main/kotlin/org/waste/of/time/storage/serializable/BlockEntityLoadable.kt
@@ -1,6 +1,7 @@
 package org.waste.of.time.storage.serializable
 
 import net.minecraft.block.entity.BlockEntity
+import net.minecraft.block.entity.ChiseledBookshelfBlockEntity
 import net.minecraft.block.entity.LecternBlockEntity
 import net.minecraft.block.entity.LockableContainerBlockEntity
 import net.minecraft.world.chunk.WorldChunk
@@ -45,6 +46,7 @@ class BlockEntityLoadable(
                         when (blockEntity) {
                             is LockableContainerBlockEntity -> blockEntity.migrateData(existing)
                             is LecternBlockEntity -> blockEntity.migrateData(existing)
+                            is ChiseledBookshelfBlockEntity -> blockEntity.migrateData(existing)
                         }
                     }
             }
@@ -63,6 +65,14 @@ class BlockEntityLoadable(
         if (existing !is LecternBlockEntity) return
         if (!book.isEmpty) return
         book = existing.book
+        markScanned(true)
+        migrated = true
+    }
+
+    private fun ChiseledBookshelfBlockEntity.migrateData(existing: BlockEntity) {
+        if (existing !is ChiseledBookshelfBlockEntity) return
+        if (!isEmpty) return
+        repeat(size()) { slot -> setStack(slot, existing.getStack(slot)) }
         markScanned(true)
         migrated = true
     }

--- a/common/src/main/resources/worldtools.accesswidener
+++ b/common/src/main/resources/worldtools.accesswidener
@@ -15,3 +15,4 @@ accessible field net/minecraft/entity/player/PlayerEntity enderChestInventory Ln
 accessible method net/minecraft/block/entity/LockableContainerBlockEntity getHeldStacks ()Lnet/minecraft/util/collection/DefaultedList;
 accessible method net/minecraft/block/entity/LockableContainerBlockEntity setHeldStacks (Lnet/minecraft/util/collection/DefaultedList;)V
 accessible method net/minecraft/world/chunk/SerializedChunk toNbt ([Lit/unimi/dsi/fastutil/shorts/ShortList;)Lnet/minecraft/nbt/NbtList;
+accessible method net/minecraft/block/ChiseledBookshelfBlock getSlotForHitPos (Lnet/minecraft/util/hit/BlockHitResult;Lnet/minecraft/block/BlockState;)Ljava/util/OptionalInt;


### PR DESCRIPTION
Hook ClientPlayInteractionManagerMixin so that right-clicking a chiseled bookshelf reads its slot stacks before the server's pickup or place response mutates them. Forward the resulting inventory state through DataInjectionHandler and BlockEntityLoadable so the capture pipeline records it.

The accesswidener entry for ChiseledBookshelfBlock.getSlotForHitPos is what permits the slot-index read from the mixin.

Closes #56

## Verification

Chiseled bookshelf at in an server capture saved with slots 0/1/4 = enchanted_book, enchanted_book, written_book after in-game right-click, matching the live state.